### PR TITLE
Added some error reporting (stream emit) to publisher.publish

### DIFF
--- a/lib/error-reporter.js
+++ b/lib/error-reporter.js
@@ -1,0 +1,24 @@
+/**
+ * create an error reporter
+ * @param {Object} err The error to report on
+ */
+
+module.exports = function(err) {
+
+  switch(err.Code[0]) {
+
+    case 'PermanentRedirect':
+      return 'Error: ' + err.Code + '. ' + err.Message + '.. ' + err.Endpoint;
+      break;
+
+    case 'NoSuckBucket':
+      return 'Error: ' + err.Code + '. ' + err.Message + '... ' + err.BucketName;
+      break;
+
+    default:
+      return 'Error: ' + err.Code + '. ' + err.Message;
+      break;
+
+  }
+
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,10 @@ var Stream = require('stream'),
     crypto = require('crypto'),
     knox = require('knox'),
     mime = require('mime'),
-    gutil = require('gulp-util');
+    gutil = require('gulp-util'),
+    PluginError = gutil.PluginError,
+    parseString = require('xml2js').parseString,
+    errorReporter = require('./error-reporter');
 
 /**
  * calculate file hash
@@ -37,6 +40,35 @@ function initFile(file) {
     file.s3.path = file.path.replace(file.base, '');
   }
   return file;
+}
+
+/**
+ * return the error XML from an AWS request
+ * @param  {Object}   res The response to parse the error from
+ * @param  {Function} cb  The callback to respond to
+ *
+ * @api private
+ */
+function readResponseBody(res, cb) {
+
+  var body = '';
+
+  res.on('data', function (chunk) {
+
+    body += chunk.toString();
+
+  });
+
+  res.on('end', function () {
+
+    parseString(body, function (err, result) {
+
+      cb(err, result.Error);
+
+    });
+
+  });
+
 }
 
 /**
@@ -163,7 +195,7 @@ Publisher.prototype.cache = function() {
       } else if (file.s3.etag) {
         _this._cache[file.s3.path] = file.s3.etag;
       }
-      
+
       // save cache every 10 files
       if (++counter % 10) _this.saveCache();
     }
@@ -198,7 +230,7 @@ Publisher.prototype.publish = function (headers) {
   if(!headers['x-amz-acl']) headers['x-amz-acl'] = 'public-read';
 
   return through.obj(function (file, enc, cb) {
-    var header, etag;
+    var header, etag, _stream = this;
 
     // Do nothing if no contents
     if (file.isNull()) return cb();
@@ -238,7 +270,11 @@ Publisher.prototype.publish = function (headers) {
 
       // get s3 headers
       _this.client.headFile(file.s3.path, function(err, res) {
-        if (err) return cb(err);
+
+        if (err) {
+          _stream.emit('error', new PluginError('gulp-awspublish', err));
+          return cb(err);
+        }
 
         // skip: file are identical
         if (res.headers.etag === etag) {
@@ -252,9 +288,24 @@ Publisher.prototype.publish = function (headers) {
             ? 'update'
             : 'create';
 
-          _this.client.putBuffer(file.contents, file.s3.path.replace(/\\/g, '/'), file.s3.headers, function(err) {
+          _this.client.putBuffer(file.contents, file.s3.path.replace(/\\/g, '/'), file.s3.headers, function(err, res) {
+
             if (!err) file.s3.etag = etag;
-            cb(err, file);
+
+            if (res.statusCode === 200) {
+              return cb(err, file);
+            }
+
+            // parse out and emit the error
+            readResponseBody(res, function (err, body) {
+
+              file.s3.state = 'error';
+              _stream.emit('error', new PluginError('gulp-awspublish', errorReporter(body)));
+
+              cb(err, file);
+
+            });
+
           });
         }
       });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "mime": "1.x",
     "clone": "0.x",
     "pad-component": "0.x",
-    "event-stream": "3.x"
+    "event-stream": "3.x",
+    "xml2js": "~0.4.1"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Not sure if this is where you would have taken it, but perhaps it's a good start and can be refactored?

I've only tackled publiser.publish at this point.

I initially had some error inspection on each client.headFile request, but I decided to take that out. I'm pretty sure a 404 would be normal if the actual file being published doesn't actually exist yet within the S3 bucket.

I also added the 'error' state to file.s3.state, which is new. I'm not sure how this affect things downstream, you'd know better than I. It outputs error to console quite okay though, which is useful.

I've been using gulp-plumber and it's working quite well.
