### PR TITLE
Fix relative paths on Windows. Fixes pgherveou/gulp-awspublish#20

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ function initFile(file) {
   if (!file.s3) {
     file.s3 = {};
     file.s3.headers = {};
-    file.s3.path = file.path.replace(file.base, '');
+    file.s3.path = file.path.substring(file.base.length);
   }
   return file;
 }


### PR DESCRIPTION
``` javascript
function initFile(file) {
  if (!file.s3) {
    file.s3 = {};
    file.s3.headers = {};
    file.s3.path = file.path.substring(file.base.length);
  }
  return file;
}
```

**Test case**:

file.path = "C:/Projects/Project1/build/index.html"
file.base = "C:\Projects\Project1\build\"

`file.path.substring(file.base.length)` will return `index.html`
