### PR TITLE
options.createOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Create a through stream, that push files to s3.
 - options: optional additional publishing options
   - force: bypass cache / skip
   - simulate: debugging option to simulate s3 upload
+  - createOnly: skip file updates
 
 Files that go through the stream receive extra properties:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -273,9 +273,12 @@ Publisher.prototype.publish = function (headers, options) {
         if (res.statusCode !== 200 && res.statusCode !== 307 && res.statusCode !== 404) {
           return cb(new S3Error(res));
         }
-
+        // skip: no updates allowed
+        var noUpdate = options.createOnly && res.headers.etag;
         // skip: file are identical
-        if (!options.force && res.headers.etag === etag) {
+        var noChange = !options.force && res.headers.etag === etag;
+
+        if (noUpdate || noChange) {
           file.s3.state = 'skip';
           file.s3.etag = etag;
           file.s3.date = new Date(res.headers['last-modified']);

--- a/test/index.js
+++ b/test/index.js
@@ -166,12 +166,32 @@ describe('gulp-awspublish', function () {
       stream.end();
     });
 
-    it('should update exsiting file on s3', function (done) {
+    it('should update existing file on s3', function (done) {
       var stream = publisher.publish();
       stream.pipe(es.writeArray(function(err, files) {
         expect(err).not.to.exist;
         expect(files).to.have.length(1);
         expect(files[0].s3.state).to.eq('update');
+        done(err);
+      }));
+
+      stream.write(new gutil.File({
+        path: '/test/hello.txt',
+        base: '/',
+        contents: new Buffer('hello world 2')
+      }));
+
+      stream.end();
+    });
+
+    it('can skip updating an existing file on s3 (createOnly)', function (done) {
+      var stream = publisher.publish({}, {
+        createOnly: true
+      });
+      stream.pipe(es.writeArray(function(err, files) {
+        expect(err).not.to.exist;
+        expect(files).to.have.length(1);
+        expect(files[0].s3.state).to.eq('skip');
         done(err);
       }));
 


### PR DESCRIPTION
You may be interested in a use case where updates are undesirable.

This PR adds an option that causes potential file updates to result in skips.
