### PR TITLE
Handling S3 - 307 Status code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -270,7 +270,7 @@ Publisher.prototype.publish = function (headers, options) {
       // get s3 headers
       _this.client.headFile(file.s3.path, function(err, res) {
         if (err) return cb(err);
-        if (res.statusCode !== 200 && res.statusCode !== 404) {
+        if (res.statusCode !== 200 && res.statusCode !== 307 && res.statusCode !== 404) {
           return cb(new S3Error(res));
         }
 
@@ -289,7 +289,7 @@ Publisher.prototype.publish = function (headers, options) {
 
           _this.client.putBuffer(file.contents, file.s3.path.replace(/\\/g, '/'), file.s3.headers, function(err, res) {
             if (err) return cb(err);
-            if (res.statusCode !== 200) {
+            if (res.statusCode !== 200 && res.statusCode !== 307) {
               return cb(new S3Error(res));
             }
 


### PR DESCRIPTION
When the bucket is just created and the DNS on amazon isn't synched fully, it will send you a redirect (307).
In these cases no error should be thrown. This commit fixes that.

For more information see:
- https://github.com/LearnBoost/knox/issues/66
- http://docs.aws.amazon.com/AmazonS3/latest/dev/Redirects.html
