### PR TITLE
refactored to use aws-sdk instead of knox

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var awspublish = require('gulp-awspublish');
 gulp.task('publish', function() {
 
   // create a new publisher
-  var publisher = awspublish.create({ key: '...',  secret: '...', bucket: '...' });
+  var publisher = awspublish.create({ bucket: '...' });
 
   // define custom headers
   var headers = {
@@ -58,6 +58,9 @@ gulp.task('publish', function() {
 // ...
 ```
 
+* Note: If you follow the [aws-sdk suggestions](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) for
+  providing your credentials you don't need to pass them in to create the publisher.
+
 ## Testing
 
 add an aws-credentials.json json file to the project directory
@@ -83,8 +86,12 @@ Available options:
 ### awspublish.create(options)
 
 Create a Publisher.
-Options are passed to knox to create a s3 client.
-Please see [knox](https://github.com/LearnBoost/knox#client-creation-options) for more details about these options
+Options are used to create an `aws-sdk` S3 client. At a minimum you must pass
+a `bucket` option, to define the site bucket. If you are using the [aws-sdk suggestions](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) for credentials you do not need
+to provide anything else.
+
+Also supports credentials specified in the old [knox](https://github.com/LearnBoost/knox#client-creation-options)
+format, a `profile` property for choosing a specific set of shared AWS creds, or and `accessKeyId` and `secretAccessKey` provided explicitly.
 
 #### Publisher.publish([headers], [options])
 
@@ -137,7 +144,7 @@ gulp.src('./public/*')
 
 #### Publisher.client
 
-The knox client object exposed to let you do other s3 operations.
+The `aws-sdk` S3 client is exposed to let you do other s3 operations.
 
 ### awspublish.reporter([options])
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,16 @@
-var Stream = require('stream'),
+var AWS = require('aws-sdk'),
+    XmlStream = require('xml-stream'),
+    Stream = require('stream'),
     util = require('util'),
-    S3Lister = require('s3-lister'),
-    S3Deleter = require('s3-deleter'),
-    es = require('event-stream'),
     fs = require('fs'),
     through = require('through2'),
     zlib = require('zlib'),
     crypto = require('crypto'),
-    knox = require('knox'),
     mime = require('mime'),
+    pascalCase = require('pascal-case'),
     gutil = require('gulp-util');
+
+var PLUGIN_NAME = 'gulp-awspublish';
 
 /**
  * calculate file hash
@@ -38,6 +39,76 @@ function S3Error(res) {
 }
 
 util.inherits(S3Error, Error);
+
+/**
+ * Hunt for appropriate creds
+ * @param {Options} opts
+ *
+ * @return {Credentials} obj
+ * @api private
+ */
+
+function getCredentials(opts) {
+  if (opts && opts instanceof AWS.SharedIniFileCredentials && !opts.accessKeyId) {
+    return new gutil.PluginError({
+      plugin: PLUGIN_NAME,
+      message: 'Bad or invalid credentials'
+    });
+  }
+
+  // compatibility
+  if (opts && opts.key && (opts.secret || opts.token)) {
+    return {
+      accessKeyId: opts.key,
+      secretAccessKey: opts.secret,
+      sessionToken: opts.token
+    };
+  }
+
+  // When passing to S3, the non-enumerated secretKey won't get copied
+  if (opts && opts instanceof AWS.SharedIniFileCredentials) {
+    return {
+      accessKeyId: opts.accessKeyId,
+      secretAccessKey: opts.secretAccessKey,
+      sessionToken: opts.sessionToken
+    };
+  }
+
+  if (opts && opts.accessKeyId && (opts.secretAccessKey || opts.sessionToken)) {
+    return {
+      accessKeyId: opts.accessKeyId,
+      secretAccessKey: opts.secretAccessKey,
+      sessionToken: opts.sessionToken
+    };
+  }
+
+  if (AWS.config.credentials) {
+    return getCredentials(AWS.config.credentials);
+  }
+
+  return getCredentials(new AWS.SharedIniFileCredentials(opts));
+}
+
+/**
+ * Turn the HTTP style headers into AWS Object params
+ */
+
+function headersToAwsParams(headers) {
+  var params = {};
+
+  for (var header in headers) {
+    if (header === 'x-amz-acl') {
+
+      params.ACL = headers[header];
+
+    } else {
+
+      params[pascalCase(header)] = headers[header];
+    }
+  }
+
+  return params;
+}
 
 
 /**
@@ -82,7 +153,7 @@ module.exports.gzip = function(options) {
     // streams not supported
     if (file.isStream()) {
       this.emit('error',
-        new gutil.PluginError('gulp-awspublish', 'Stream content is not supported'));
+        new gutil.PluginError(PLUGIN_NAME, 'Stream content is not supported'));
       return cb();
     }
 
@@ -132,10 +203,29 @@ module.exports.reporter = function(param) {
  */
 
 function Publisher(config) {
-  var filename = '.awspublish-' + config.bucket;
+  if (!config.bucket) {
+    throw new gutil.PluginError({
+      plugin: PLUGIN_NAME,
+      message: 'No bucket specified'
+    });
+  }
+
+  this._bucket = config.bucket;
+  var filename = '.awspublish-' + this._bucket;
 
   // create client
-  this.client = knox.createClient(config);
+  var credentials = getCredentials(config);
+  if (credentials instanceof Error) {
+    throw credentials;
+  }
+
+  var s3Opts = credentials;
+
+  s3Opts.params = {
+    Bucket: this._bucket
+  };
+
+  this.client = new AWS.S3(s3Opts);
 
   // load cache
   try {
@@ -152,7 +242,7 @@ function Publisher(config) {
  */
 
 Publisher.prototype.saveCache = function() {
-  var filename = '.awspublish-' + this.client.bucket;
+  var filename = '.awspublish-' + this._bucket;
   fs.writeFileSync(filename, JSON.stringify(this._cache));
 };
 
@@ -231,7 +321,7 @@ Publisher.prototype.publish = function (headers, options) {
     // streams not supported
     if (file.isStream()) {
       this.emit('error',
-        new gutil.PluginError('gulp-awspublish', 'Stream content is not supported'));
+        new gutil.PluginError(PLUGIN_NAME, 'Stream content is not supported'));
       return cb();
     }
 
@@ -268,35 +358,38 @@ Publisher.prototype.publish = function (headers, options) {
       if (options.simulate) return cb(null, file);
 
       // get s3 headers
-      _this.client.headFile(file.s3.path, function(err, res) {
-        if (err) return cb(err);
-        if (res.statusCode !== 200 && res.statusCode !== 307 && res.statusCode !== 404) {
-          return cb(new S3Error(res));
-        }
+      _this.client.headObject({ Key: file.s3.path }, function(err, res) {
+        if (err && err.statusCode !== 404) return cb(err);
+
+        res = res || {};
+
         // skip: no updates allowed
-        var noUpdate = options.createOnly && res.headers.etag;
+        var noUpdate = options.createOnly && res.ETag;
+
         // skip: file are identical
-        var noChange = !options.force && res.headers.etag === etag;
+        var noChange = !options.force && res.ETag === etag;
 
         if (noUpdate || noChange) {
           file.s3.state = 'skip';
           file.s3.etag = etag;
-          file.s3.date = new Date(res.headers['last-modified']);
+          file.s3.date = new Date(res.LastModified);
           cb(err, file);
 
         // update: file are different
         } else {
-          file.s3.state = res.headers.etag
+          file.s3.state = res.ETag
             ? 'update'
             : 'create';
 
-          _this.client.putBuffer(file.contents, file.s3.path, file.s3.headers, function(err, res) {
-            if (err) return cb(err);
-            if (res.statusCode !== 200 && res.statusCode !== 307) {
-              return cb(new S3Error(res));
-            }
+          var params = headersToAwsParams(file.s3.headers);
 
-            file.s3.date = new Date(res.headers.date);
+          params.Key = file.s3.path;
+          params.Body = file.contents;
+
+          _this.client.putObject(params, function(err, res) {
+            if (err) return cb(err);
+
+            file.s3.date = new Date(res.LastModified);
             file.s3.etag = etag;
             cb(err, file);
           });
@@ -329,33 +422,51 @@ Publisher.prototype.sync = function(prefix) {
   };
 
   stream._flush = function(cb) {
-    var lister = new S3Lister(client, { prefix : prefix }),
-        deleter = new S3Deleter(client),
+    var listParams = {
+      Prefix: prefix
+    };
+
+    var lister = client.listObjects(listParams).createReadStream(),
+        listerXmlStream = new XmlStream(lister),
+        deleter,
+        toDelete = [],
         filter;
 
     // filter out newfiles and add deleted file to stream
-    filter = es.mapSync(function(data) {
-      var s3path = data.Key;
-      if (newFiles[s3path]) return;
+    filter = function (el) {
+      var key = el.$text;
+      if (newFiles[key]) return;
 
       stream.push({
         s3: {
-          path: s3path,
+          path: key,
           state: 'delete',
           headers: {}
         }
       });
 
-      return data;
-    });
+      toDelete.push(key);
+    };
 
-    lister.on('error', cb);
-    deleter.on('error', cb);
+    // Makes a batch delete request
+    deleter = function () {
+      if (!toDelete.length) {
+        return cb();
+      }
 
-    lister
-      .pipe(filter)
-      .pipe(deleter)
-      .on('finish', cb);
+      var deleteObjects = toDelete.map(function (k) { return { Key: k }; });
+      var deleteParams = {
+        Delete: {
+          Objects: deleteObjects
+        }
+      };
+
+      client.deleteObjects(deleteParams, cb);
+    };
+
+    listerXmlStream.on('endElement: Contents > Key', filter);
+    listerXmlStream.on('error', cb);
+    listerXmlStream.on('end', deleter);
   };
 
   return stream;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 var AWS = require('aws-sdk'),
     XmlStream = require('xml-stream'),
     Stream = require('stream'),
-    util = require('util'),
     fs = require('fs'),
     through = require('through2'),
     zlib = require('zlib'),
@@ -26,19 +25,6 @@ function md5Hash(buf) {
     .update(buf)
     .digest('hex');
 }
-
-/**
- * S3 Error class
- * @param {Response} res
- */
-
-function S3Error(res) {
-  Error.call(this);
-  this.message = 'HTTP ' + res.statusCode + ' Response returned from S3';
-  this.res = res;
-}
-
-util.inherits(S3Error, Error);
 
 /**
  * Hunt for appropriate creds
@@ -93,8 +79,10 @@ function getCredentials(opts) {
  * Turn the HTTP style headers into AWS Object params
  */
 
-function headersToAwsParams(headers) {
+function toAwsParams(file) {
   var params = {};
+
+  var headers = file.s3.headers || {};
 
   for (var header in headers) {
     if (header === 'x-amz-acl') {
@@ -107,9 +95,13 @@ function headersToAwsParams(headers) {
     }
   }
 
+  params.Key = file.s3.path;
+  params.Body = file.contents;
+
   return params;
 }
 
+module.exports._toAwsParams = toAwsParams;
 
 /**
  * init file s3 hash
@@ -127,6 +119,20 @@ function initFile(file) {
   }
   return file;
 }
+
+function buildDeleteMultiple(keys) {
+  if (!keys || !keys.length) return;
+
+  var deleteObjects = keys.map(function (k) { return { Key: k }; });
+
+  return {
+    Delete: {
+      Objects: deleteObjects
+    }
+  };
+}
+
+module.exports._buildDeleteMultiple = buildDeleteMultiple;
 
 /**
  * create a through stream that gzip files
@@ -381,15 +387,10 @@ Publisher.prototype.publish = function (headers, options) {
             ? 'update'
             : 'create';
 
-          var params = headersToAwsParams(file.s3.headers);
-
-          params.Key = file.s3.path;
-          params.Body = file.contents;
-
-          _this.client.putObject(params, function(err, res) {
+          _this.client.putObject(toAwsParams(file), function(err) {
             if (err) return cb(err);
 
-            file.s3.date = new Date(res.LastModified);
+            file.s3.date = new Date();
             file.s3.etag = etag;
             cb(err, file);
           });
@@ -454,14 +455,7 @@ Publisher.prototype.sync = function(prefix) {
         return cb();
       }
 
-      var deleteObjects = toDelete.map(function (k) { return { Key: k }; });
-      var deleteParams = {
-        Delete: {
-          Objects: deleteObjects
-        }
-      };
-
-      client.deleteObjects(deleteParams, cb);
+      client.deleteObjects(buildDeleteMultiple(toDelete), cb);
     };
 
     listerXmlStream.on('endElement: Contents > Key', filter);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var AWS = require('aws-sdk'),
-    XmlStream = require('xml-stream'),
+    converter = require('xml-json'),
     Stream = require('stream'),
     fs = require('fs'),
     through = require('through2'),
@@ -423,21 +423,15 @@ Publisher.prototype.sync = function(prefix) {
   };
 
   stream._flush = function(cb) {
-    var listParams = {
-      Prefix: prefix
-    };
+    var toDelete = [],
+        lister;
 
-    var lister = client.listObjects(listParams).createReadStream(),
-        listerXmlStream = new XmlStream(lister),
-        deleter,
-        toDelete = [],
-        filter;
+    lister = client.listObjects({ Prefix: prefix })
+      .createReadStream()
+      .pipe(converter('Key'));
 
-    // filter out newfiles and add deleted file to stream
-    filter = function (el) {
-      var key = el.$text;
+    lister.on('data', function (key) {
       if (newFiles[key]) return;
-
       stream.push({
         s3: {
           path: key,
@@ -445,22 +439,13 @@ Publisher.prototype.sync = function(prefix) {
           headers: {}
         }
       });
-
       toDelete.push(key);
-    };
+    });
 
-    // Makes a batch delete request
-    deleter = function () {
-      if (!toDelete.length) {
-        return cb();
-      }
-
+    lister.on('end', function() {
+      if (!toDelete.length) return cb();
       client.deleteObjects(buildDeleteMultiple(toDelete), cb);
-    };
-
-    listerXmlStream.on('endElement: Contents > Key', filter);
-    listerXmlStream.on('error', cb);
-    listerXmlStream.on('end', deleter);
+    });
   };
 
   return stream;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pad-component": "0.x",
     "pascal-case": "^1.1.0",
     "through2": "0.x",
-    "xml-stream": "^0.4.5"
+    "xml-json": "^2.0.2"
   },
   "devDependencies": {
     "chai": "*",

--- a/package.json
+++ b/package.json
@@ -25,15 +25,14 @@
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "through2": "0.x",
-    "gulp-util": "2.x",
-    "knox": "0.x",
-    "mime": "1.x",
+    "aws-sdk": "^2.1.7",
     "clone": "0.x",
+    "gulp-util": "2.x",
+    "mime": "1.x",
     "pad-component": "0.x",
-    "event-stream": "3.x",
-    "s3-lister": "0.x",
-    "s3-deleter": "0.x"
+    "pascal-case": "^1.1.0",
+    "through2": "0.x",
+    "xml-stream": "^0.4.5"
   },
   "devDependencies": {
     "chai": "*",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chai": "*",
     "concurrent-transform": "^1.0.0",
     "coveralls": "*",
+    "event-stream": "^3.2.1",
     "gulp-rename": "*",
     "istanbul": "*",
     "mocha": "*",


### PR DESCRIPTION
Per #32 I've refactored the module to use the aws-sdk instead of Knox.

I haven't added or removed any functionality -- just replaced Knox and dependent modules with aws-sdk and one other dependency.

I think this is worthwhile because it seems aws-sdk will have better long term support. I'd also like to add functionality that handles the `putBucketWebsite` for a more complete package, and I found that nearly impossible to do with Knox.