### PR TITLE
config: fix region setting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -231,6 +231,10 @@ function Publisher(config) {
     Bucket: this._bucket
   };
 
+  if (typeof config.region === 'string') {
+    s3Opts.region = config.region;
+  }
+
   this.client = new AWS.S3(s3Opts);
 
   // load cache


### PR DESCRIPTION
The recent switch to aws-sdk broke non-standard regions. `config.region` didn't get passed to S3 anymore.
This fixes it.