### PR TITLE
Don't attempt to validate credentials [Fixes #45]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,13 +35,6 @@ function md5Hash(buf) {
  */
 
 function getCredentials(opts) {
-  if (opts && opts instanceof AWS.SharedIniFileCredentials && !opts.accessKeyId) {
-    return new gutil.PluginError({
-      plugin: PLUGIN_NAME,
-      message: 'Bad or invalid credentials'
-    });
-  }
-
   // compatibility
   if (opts && opts.key && (opts.secret || opts.token)) {
     return {


### PR DESCRIPTION
This check that is being removed prevents gulp-awspublish from working
correctly on EC2 instances configured with an IAM Instance Profile.

The AWS SDK will bail out if credentials are incorrectly configured.