### PR TITLE
Respect AWS credentials profile when supplied in options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ function getCredentials(opts) {
     };
   }
 
-  if (AWS.config.credentials) {
+  if (!opts.profile && AWS.config.credentials) {
     return getCredentials(AWS.config.credentials);
   }
 


### PR DESCRIPTION
The README mentions "a profile property for choosing a specific set of shared AWS creds".

Here is an example where a profile is supplied:

```
awsPublisher = function awsPublisher() {
  var aws = {
    profile: 'my-profile',
    bucket: 'my-s3-bucket'
  };

  return awspublish.create(aws);
};
```

Currently this does not work. The `profile` value is ignored in favour of the default profile in `~/.aws/credentials`.

This pull request fixes this and ensures the profile is respected by using `AWS.SharedIniFileCredentials` instead of `AWS.config.credentials` if a profile is supplied. 

This appears to be the recommended method in the AWS SDK docs - http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Using_Profiles_with_the_SDK