### PR TITLE
Preserve content type header on gzip

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,23 @@ function getCredentials(opts) {
 }
 
 /**
+ * Determine the content type of a file based on charset and mime type.
+ * @param  {Object} file
+ * @return {String}
+ *
+ * @api private
+ */
+
+function getContentType(file) {
+  var mimeType = mime.lookup(file.unzipPath || file.path);
+  var charset = mime.charsets.lookup(mimeType);
+
+  return charset
+    ? mimeType + '; charset=' + charset.toLowerCase()
+    : mimeType;
+}
+
+/**
  * Turn the HTTP style headers into AWS Object params
  */
 
@@ -161,12 +178,13 @@ module.exports.gzip = function(options) {
 
       initFile(file);
 
-      // add content-type header
+      // add content-encoding header
       file.s3.headers['Content-Encoding'] = 'gzip';
 
       // zip file
       zlib.gzip(file.contents, function(err, buf) {
         if (err) return cb(err);
+        file.unzipPath = file.path;
         file.path += options.ext;
         file.s3.path += options.ext;
         file.contents = buf;
@@ -316,7 +334,7 @@ Publisher.prototype.publish = function (headers, options) {
   if(!headers['x-amz-acl']) headers['x-amz-acl'] = 'public-read';
 
   return through.obj(function (file, enc, cb) {
-    var header, etag, mimeType, charset;
+    var header, etag;
 
     // Do nothing if no contents
     if (file.isNull()) return cb();
@@ -346,11 +364,7 @@ Publisher.prototype.publish = function (headers, options) {
       }
 
       // add content-type header
-      mimeType = mime.lookup(file.path);
-      charset = mime.charsets.lookup(mimeType);
-      file.s3.headers['Content-Type'] = charset
-        ? mimeType + '; charset=' + charset.toLowerCase()
-        : mimeType;
+      file.s3.headers['Content-Type'] = getContentType(file);
 
       // add content-length header
       file.s3.headers['Content-Length'] = file.contents.length;

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,7 @@ describe('gulp-awspublish', function () {
           expect(err).not.to.exist;
           expect(files).to.have.length(1);
           expect(files[0].path).to.eq('/test/hello.txt.gz');
+          expect(files[0].unzipPath).to.eq('/test/hello.txt');
           expect(files[0].s3.path).to.eq('test/hello.txt.gz');
           expect(files[0].s3.headers['Content-Encoding']).to.eq('gzip');
 
@@ -102,6 +103,7 @@ describe('gulp-awspublish', function () {
         .pipe(es.writeArray(function(err, files) {
           expect(err).not.to.exist;
           expect(files).to.have.length(1);
+          expect(files[0].s3.headers['Content-Type']).to.eq('text/plain; charset=utf-8');
           publisher.client.headObject({ Key: 'test/hello.txt.gz' }, function(err, res) {
             expect(res.ETag).to.exist;
             done(err);


### PR DESCRIPTION
Hello! Thanks for creating a very helpful package.

I'm having some issues with syncing gzipped encoded assets. Currently they're being synced with `application/octet-stream` rather than their original content type which makes my app unable to serve up the gzipped assets.

This fixes the issue for me - does this seem sane?