### PR TITLE
Support for Expires & Cache-Control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Options are used to create an `aws-sdk` S3 client. At a minimum you must pass
 a `bucket` option, to define the site bucket. If you are using the [aws-sdk suggestions](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) for credentials you do not need
 to provide anything else.
 
+You may pass an `expires` option. If this is set, `Expires` and `Cache-Control`
+headers will be set for objects uploaded to S3. The `expires` option must be an
+integer, and it should be to the number of seconds the object should be cached
+by clients.
+
 Also supports credentials specified in the old [knox](https://github.com/LearnBoost/knox#client-creation-options)
 format, a `profile` property for choosing a specific set of shared AWS creds, or and `accessKeyId` and `secretAccessKey` provided explicitly.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -249,6 +249,11 @@ function Publisher(config) {
 
   this.client = new AWS.S3(s3Opts);
 
+  this.expires = false;
+  if (config.expires) {
+    this.expires = config.expires;
+  }
+
   // load cache
   try {
     this._cache = JSON.parse(fs.readFileSync(filename, 'utf8'));
@@ -369,6 +374,13 @@ Publisher.prototype.publish = function (headers, options) {
 
       // add content-length header
       file.s3.headers['Content-Length'] = file.contents.length;
+
+      // add cache-control and expires headers
+      if (_this.expires){
+
+        file.s3.headers['Expires'] = new Date(Date.now() + (_this.expires*1000));
+        file.s3.headers['Cache-Control'] = 'max-age=' + _this.expires;
+      }
 
       // add extra headers
       for (header in headers) file.s3.headers[header] = headers[header];


### PR DESCRIPTION
This pull request adds an `expires` option to the Publisher. When `expires` is set, objects will have `Expires` and `Cache-Control` metadata set in S3.