### PR TITLE
Fixes how publisher takes in configuration to allow all S3 options to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ var awspublish = require('gulp-awspublish');
 
 gulp.task('publish', function() {
 
-  // create a new publisher (the aws sdk will get credentials automatically)
-  // http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html
-  var publisher = awspublish.create({ 
-     "bucket": "...",
-     "region": "..."
-   });
+  // create a new publisher using S3 options
+  // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
+  var publisher = awspublish.create({
+    params: {
+      Bucket: '...'
+    }
+  });
 
   // define custom headers
   var headers = {
-     'Cache-Control': 'max-age=315360000, no-transform, public'
-     // ...
-   };
+    'Cache-Control': 'max-age=315360000, no-transform, public'
+    // ...
+  };
 
   return gulp.src('./public/*.js')
-
      // gzip, Set Content-Encoding headers and add .gz extension
     .pipe(awspublish.gzip({ ext: '.gz' }))
 
@@ -64,10 +64,12 @@ add an aws-credentials.json json file to the project directory
 with your bucket credentials, then run mocha.
 
 ```json
- {
-  "key": "...",
-  "secret": "...",
-  "bucket": "..."
+{
+  "params": {
+    "Bucket": "..."
+  },
+  "accessKeyId": "...",
+  "secretAccessKey": "..."
 }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,48 +28,6 @@ function md5Hash(buf) {
 }
 
 /**
- * Hunt for appropriate creds
- * @param {Options} opts
- *
- * @return {Credentials} obj
- * @api private
- */
-
-function getCredentials(opts) {
-  // compatibility
-  if (opts && opts.key && (opts.secret || opts.token)) {
-    return {
-      accessKeyId: opts.key,
-      secretAccessKey: opts.secret,
-      sessionToken: opts.token
-    };
-  }
-
-  // When passing to S3, the non-enumerated secretKey won't get copied
-  if (opts && opts instanceof AWS.SharedIniFileCredentials) {
-    return {
-      accessKeyId: opts.accessKeyId,
-      secretAccessKey: opts.secretAccessKey,
-      sessionToken: opts.sessionToken
-    };
-  }
-
-  if (opts && opts.accessKeyId && (opts.secretAccessKey || opts.sessionToken)) {
-    return {
-      accessKeyId: opts.accessKeyId,
-      secretAccessKey: opts.secretAccessKey,
-      sessionToken: opts.sessionToken
-    };
-  }
-
-  if (!opts.profile && AWS.config.credentials) {
-    return getCredentials(AWS.config.credentials);
-  }
-
-  return getCredentials(new AWS.SharedIniFileCredentials(opts));
-}
-
-/**
  * Determine the content type of a file based on charset and mime type.
  * @param  {Object} file
  * @return {String}
@@ -209,63 +167,36 @@ module.exports.reporter = function(param) {
 
 /**
  * create a new Publisher
- * @see Knox.createClient()
- * @param {Object} knox option object
- *
- * options keys are:
- *   key: amazon key,
- *   secret: amazon secret,
- *   bucket: amazon bucket
- *
+ * @param {Object} S3 options as per http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
  * @api private
  */
 
 function Publisher(config) {
-  if (!config.bucket) {
-    throw new gutil.PluginError({
-      plugin: PLUGIN_NAME,
-      message: 'No bucket specified'
-    });
-  }
-
-  this._bucket = config.bucket;
-  var filename = '.awspublish-' + this._bucket;
-
-  // create client
-  var credentials = getCredentials(config);
-  if (credentials instanceof Error) {
-    throw credentials;
-  }
-
-  var s3Opts = credentials;
-
-  s3Opts.params = {
-    Bucket: this._bucket
-  };
-
-  if (typeof config.region === 'string') {
-    s3Opts.region = config.region;
-  }
-
-  this.client = new AWS.S3(s3Opts);
+  this.config = config;
+  this.client = new AWS.S3(config);
 
   // load cache
   try {
-    this._cache = JSON.parse(fs.readFileSync(filename, 'utf8'));
+    this._cache = JSON.parse(fs.readFileSync(this.getCacheFilename(), 'utf8'));
   } catch (err) {
     this._cache = {};
   }
 }
 
 /**
- * save cache file to disk
- *
- * @api privare
+ * generates cache filename.
+ * @return {String}
+ * @api private
  */
 
-Publisher.prototype.saveCache = function() {
-  var filename = '.awspublish-' + this._bucket;
-  fs.writeFileSync(filename, JSON.stringify(this._cache));
+Publisher.prototype.getCacheFilename = function() {
+  var bucket = this.config.params['Bucket'];
+
+  if (!bucket) {
+    throw new Error('Missing `params.Bucket` config value.');
+  }
+
+  return '.awspublish-' + bucket;
 };
 
 /**
@@ -278,6 +209,10 @@ Publisher.prototype.saveCache = function() {
 Publisher.prototype.cache = function() {
   var _this = this,
       counter = 0;
+
+  function saveCache() {
+    fs.writeFileSync(_this.getCacheFilename(), JSON.stringify(_this._cache));
+  }
 
   var stream = through.obj(function (file, enc, cb) {
     if (file.s3 && file.s3.path) {
@@ -295,15 +230,13 @@ Publisher.prototype.cache = function() {
       }
 
       // save cache every 10 files
-      if (++counter % 10) _this.saveCache();
+      if (++counter % 10) saveCache();
     }
 
     cb(null, file);
   });
 
-  stream.on('finish', function() {
-    _this.saveCache();
-  });
+  stream.on('finish', saveCache);
 
   return stream;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -15,12 +15,11 @@ describe('gulp-awspublish', function () {
   this.timeout(10000);
 
   var credentials = JSON.parse(fs.readFileSync('aws-credentials.json', 'utf8')),
-      publisher = awspublish.create(credentials),
-      cacheFile = '.awspublish-' + publisher.client.bucket;
+      publisher = awspublish.create(credentials);
 
   // remove files
   before(function(done) {
-    try { fs.unlinkSync(cacheFile); } catch (err) {}
+    try { fs.unlinkSync(publisher.getCacheFilename()); } catch (err) {}
     publisher._cache = {};
 
     var deleteParams = awspublish._buildDeleteMultiple([
@@ -38,7 +37,7 @@ describe('gulp-awspublish', function () {
       var badCredentials, badPublisher, stream;
 
       badCredentials = clone(credentials);
-      badCredentials.bucket = 'fake-bucket';
+      badCredentials.params.Bucket = 'fake-bucket';
       badPublisher = awspublish.create(badCredentials),
       stream = badPublisher.publish();
 


### PR DESCRIPTION
Currently most configuration [options that S3 can take in](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property) are stripped out, which is very unfortunate. 

This patch changes to take in and pass through the options directly without any mangling or manipulation.

This should be released as version 2.0 to avoid breaking people's existing code.