### PR TITLE
Don't overwrite Content-Type and Content-Length header values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -299,7 +299,7 @@ Publisher.prototype.publish = function (headers, options) {
 
       // add content-type header
       if (!file.s3.headers['Content-Type']) file.s3.headers['Content-Type'] = getContentType(file);
-      
+
       // add content-length header
       if (!file.s3.headers['Content-Length']) file.s3.headers['Content-Length'] = file.contents.length;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -298,10 +298,10 @@ Publisher.prototype.publish = function (headers, options) {
       }
 
       // add content-type header
-      file.s3.headers['Content-Type'] = getContentType(file);
-
+      if (!file.s3.headers['Content-Type']) file.s3.headers['Content-Type'] = getContentType(file);
+      
       // add content-length header
-      file.s3.headers['Content-Length'] = file.contents.length;
+      if (!file.s3.headers['Content-Length']) file.s3.headers['Content-Length'] = file.contents.length;
 
       // add extra headers
       for (header in headers) file.s3.headers[header] = headers[header];


### PR DESCRIPTION
When trying to supply my own `Content-Type` header, I found it to not be sent to S3 correctly.
@skyzyx seems to experience this issue [as well](https://github.com/jussi-kalliokoski/gulp-awspublish-router/issues/7). 

This is exacerbated since Content-Type detection seemed unreliable for gzipped assets — it often set `application/octet-stream` instead of `text/…`.

This fix simply checks whether these two header values were already supplied before setting them.