### PR TITLE
Fix #73 - Change cache to take header changes into account

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -102,10 +102,6 @@ function buildDeleteMultiple(keys) {
   };
 }
 
-function createDefaultCacheOptions() {
-  return { headers: false };
-}
-
 module.exports._buildDeleteMultiple = buildDeleteMultiple;
 
 /**
@@ -179,7 +175,7 @@ module.exports.reporter = function(param) {
 function Publisher(config) {
   this.config = config;
   this.client = new AWS.S3(config);
-  this._cacheOptions = createDefaultCacheOptions();
+  this._cacheOptions = { headers: false };
 
   // load cache
   try {
@@ -220,14 +216,39 @@ Publisher.prototype.getCacheFilename = function() {
 
 Publisher.prototype._isFileCached = function(file, etag) {
 
-  var fileCacheItem = this._cache[file.s3.path];
+  var fileCache = this._cache[file.s3.path];
 
-  if (!fileCacheItem) return false;
+  if (!fileCache) return false;
 
-  if (fileCacheItem.etag !== etag) return false;
+  if (fileCache.etag !== etag) return false;
 
   // Header comparison is turned off.
   if (!this._cacheOptions.headers) return true;
+
+  var checkedHeaders = {};
+
+  for (var name in file.s3.headers) {
+
+    checkedHeaders[name] = true;
+
+    if (name in fileCache.headers) {
+      if (file.s3.headers[name] !== fileCache.headers[name]) {
+        // Modified header.
+        return false;
+      }
+    }
+    else {
+      // New header.
+      return false;
+    }
+  }
+
+  for (var name in fileCache.headers) {
+    if (name in checkedHeaders) continue;
+
+    // Deleted header.
+    return false;
+  }
 
   return true;
 };
@@ -235,19 +256,65 @@ Publisher.prototype._isFileCached = function(file, etag) {
 Publisher.prototype._shouldSkipFile = function(file, response, etag) {
 
   if (response.ETag !== etag) return false;
+  
+  // Normalize S3 headers.
+  var responseHeaders = {};
+  if (response.CacheControl) { responseHeaders['Cache-Control'] = response.CacheControl; }
+  if (response.ContentType) { responseHeaders['Content-Type'] = response.ContentType; }
+  if (response.ContentDisposition) { responseHeaders['Content-Disposition'] = response.ContentDisposition; }
+  if (response.ContentLanguage) { responseHeaders['Content-Language'] = response.ContentLanguage; }
+  if (response.Expires) { responseHeaders['Expires'] = response.Expires; }
+  if (response.ContentEncoding) { responseHeaders['Content-Encoding'] = response.ContentEncoding; }
 
-  // Header comparison is turned off.
-  if (!this._cacheOptions.headers) return true;
+  if (response.Metadata) {
+    for (var name in response.Metadata) {
+      responseHeaders['x-amz-meta-' + name] = response.Metadata[name];
+    }
+  }
+
+  var checkedHeaders = {};
+
+  for (var name in file.s3.headers) {
+
+    checkedHeaders[name] = true;
+
+    // Have to ignore the ACL header since it's a canned ACL name that gets
+    // transformed into an ACL and isn't returned in the response. The 
+    // S3 client's 'getObjectAcl()' could be used, but the response ACL
+    // would have to be mapped back to the canned ACL name.
+    if (name === 'x-amz-acl') {
+      continue;
+    }
+
+    if (name in responseHeaders) {
+      if (file.s3.headers[name] !== responseHeaders[name]) {
+        // Modified header.
+        return false;
+      }
+    }
+    else {
+      // New header.
+      return false;
+    }
+  }
+
+  for (var name in responseHeaders.headers) {
+
+    if (name in checkedHeaders) continue;
+
+    // Deleted header.
+    return false;
+  }
 
   return true;
-}
+};
 
 /**
  * create a through stream that save file in cache
  * @options {Object} options option hash
  *
  * available options are:
- * - headers {Boolean}|{Array of String} include headers to be cached
+ * - headers {Boolean} include file headers when checking if the file is cached
 
  * @return {Stream}
  * @api public
@@ -256,7 +323,7 @@ Publisher.prototype._shouldSkipFile = function(file, response, etag) {
 Publisher.prototype.cache = function(options) {
 
   if (!options) {
-    options = this._cacheOptions || createDefaultCacheOptions();
+    options = this._cacheOptions;
   }
 
   this._cacheOptions = options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -281,68 +281,67 @@ Publisher.prototype.publish = function (headers, options) {
     }
 
     // check if file.contents is a `Buffer`
-    if (file.isBuffer()) {
+    if (!file.isBuffer()) return;
 
-      initFile(file);
+    initFile(file);
 
-      // calculate etag
-      etag = '"' + md5Hash(file.contents) + '"';
+    // calculate etag
+    etag = '"' + md5Hash(file.contents) + '"';
 
-      // delete - stop here
-      if (file.s3.state === 'delete') return cb(null, file);
+    // delete - stop here
+    if (file.s3.state === 'delete') return cb(null, file);
 
-      // check if file is identical as the one in cache
-      if (!options.force && _this._cache[file.s3.path] === etag) {
-        file.s3.state = 'cache';
-        return cb(null, file);
-      }
-
-      // add content-type header
-      if (!file.s3.headers['Content-Type']) file.s3.headers['Content-Type'] = getContentType(file);
-
-      // add content-length header
-      if (!file.s3.headers['Content-Length']) file.s3.headers['Content-Length'] = file.contents.length;
-
-      // add extra headers
-      for (header in headers) file.s3.headers[header] = headers[header];
-
-      if (options.simulate) return cb(null, file);
-
-      // get s3 headers
-      _this.client.headObject({ Key: file.s3.path }, function(err, res) {
-        //ignore 403 and 404 errors since we're checking if a file exists on s3
-        if (err && [403, 404].indexOf(err.statusCode) < 0) return cb(err);
-
-        res = res || {};
-
-        // skip: no updates allowed
-        var noUpdate = options.createOnly && res.ETag;
-
-        // skip: file are identical
-        var noChange = !options.force && res.ETag === etag;
-
-        if (noUpdate || noChange) {
-          file.s3.state = 'skip';
-          file.s3.etag = etag;
-          file.s3.date = new Date(res.LastModified);
-          cb(err, file);
-
-        // update: file are different
-        } else {
-          file.s3.state = res.ETag
-            ? 'update'
-            : 'create';
-
-          _this.client.putObject(toAwsParams(file), function(err) {
-            if (err) return cb(err);
-
-            file.s3.date = new Date();
-            file.s3.etag = etag;
-            cb(err, file);
-          });
-        }
-      });
+    // check if file is identical as the one in cache
+    if (!options.force && _this._cache[file.s3.path] === etag) {
+      file.s3.state = 'cache';
+      return cb(null, file);
     }
+
+    // add content-type header
+    if (!file.s3.headers['Content-Type']) file.s3.headers['Content-Type'] = getContentType(file);
+
+    // add content-length header
+    if (!file.s3.headers['Content-Length']) file.s3.headers['Content-Length'] = file.contents.length;
+
+    // add extra headers
+    for (header in headers) file.s3.headers[header] = headers[header];
+
+    if (options.simulate) return cb(null, file);
+
+    // get s3 headers
+    _this.client.headObject({ Key: file.s3.path }, function(err, res) {
+      //ignore 403 and 404 errors since we're checking if a file exists on s3
+      if (err && [403, 404].indexOf(err.statusCode) < 0) return cb(err);
+
+      res = res || {};
+
+      // skip: no updates allowed
+      var noUpdate = options.createOnly && res.ETag;
+
+      // skip: file are identical
+      var noChange = !options.force && res.ETag === etag;
+
+      if (noUpdate || noChange) {
+        file.s3.state = 'skip';
+        file.s3.etag = etag;
+        file.s3.date = new Date(res.LastModified);
+        cb(err, file);
+
+      // update: file are different
+      } else {
+        file.s3.state = res.ETag
+          ? 'update'
+          : 'create';
+
+        _this.client.putObject(toAwsParams(file), function(err) {
+          if (err) return cb(err);
+
+          file.s3.date = new Date();
+          file.s3.etag = etag;
+          cb(err, file);
+        });
+      }
+    });
   });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,10 @@ function buildDeleteMultiple(keys) {
   };
 }
 
+function createDefaultCacheOptions() {
+  return { headers: false };
+}
+
 module.exports._buildDeleteMultiple = buildDeleteMultiple;
 
 /**
@@ -174,12 +178,26 @@ module.exports.reporter = function(param) {
 function Publisher(config) {
   this.config = config;
   this.client = new AWS.S3(config);
+  this._cacheOptions = createDefaultCacheOptions();
 
   // load cache
   try {
     this._cache = JSON.parse(fs.readFileSync(this.getCacheFilename(), 'utf8'));
   } catch (err) {
     this._cache = {};
+  }
+
+  // Migrate old style caches that used only ETags:
+  // { "path1": "etag1", "path2": "etag2" }
+  for (var key in this._cache) {
+    var value = this._cache[key];
+
+    if (typeof value === 'string') {
+      this._cache = {
+        etag: value,
+        headers: {}
+      };
+    }
   }
 }
 
@@ -199,14 +217,49 @@ Publisher.prototype.getCacheFilename = function() {
   return '.awspublish-' + bucket;
 };
 
+Publisher.prototype._isFileCached = function(file, etag) {
+
+  var fileCacheItem = this._cache[file.s3.path];
+
+  if (!fileCacheItem) return false;
+
+  if (fileCacheItem.etag !== etag) return false;
+
+  // Header comparison is turned off.
+  if (!this._cacheOptions.headers) return true;
+
+  return true;
+};
+
+Publisher.prototype._shouldSkipFile = function(file, response, etag) {
+
+  if (response.ETag !== etag) return false;
+
+  // Header comparison is turned off.
+  if (!this._cacheOptions.headers) return true;
+
+  return true;
+}
+
 /**
  * create a through stream that save file in cache
+ * @options {Object} options option hash
  *
+ * available options are:
+ * - headers {Boolean}|{Array of String} include headers to be cached
+
  * @return {Stream}
  * @api public
  */
 
-Publisher.prototype.cache = function() {
+Publisher.prototype.cache = function(options) {
+
+  if (!options) {
+    options = this._cacheOptions || createDefaultCacheOptions();
+  }
+
+  this._cacheOptions = options;
+
   var _this = this,
       counter = 0;
 
@@ -226,7 +279,10 @@ Publisher.prototype.cache = function() {
 
       // update others
       } else if (file.s3.etag) {
-        _this._cache[file.s3.path] = file.s3.etag;
+        _this._cache[file.s3.path] = {
+          etag: file.s3.etag,
+          headers: {}
+        };
       }
 
       // save cache every 10 files
@@ -291,12 +347,6 @@ Publisher.prototype.publish = function (headers, options) {
     // delete - stop here
     if (file.s3.state === 'delete') return cb(null, file);
 
-    // check if file is identical as the one in cache
-    if (!options.force && _this._cache[file.s3.path] === etag) {
-      file.s3.state = 'cache';
-      return cb(null, file);
-    }
-
     // add content-type header
     if (!file.s3.headers['Content-Type']) file.s3.headers['Content-Type'] = getContentType(file);
 
@@ -305,6 +355,12 @@ Publisher.prototype.publish = function (headers, options) {
 
     // add extra headers
     for (header in headers) file.s3.headers[header] = headers[header];
+
+    // check if file is identical as the one in cache
+    if (!options.force && _this._isFileCached(file, etag)) {
+      file.s3.state = 'cache';
+      return cb(null, file);
+    }
 
     if (options.simulate) return cb(null, file);
 
@@ -318,8 +374,8 @@ Publisher.prototype.publish = function (headers, options) {
       // skip: no updates allowed
       var noUpdate = options.createOnly && res.ETag;
 
-      // skip: file are identical
-      var noChange = !options.force && res.ETag === etag;
+      // skip: file is identical
+      var noChange = !options.force && _this._shouldSkipFile(file, res, etag);
 
       if (noUpdate || noChange) {
         file.s3.state = 'skip';

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ var AWS = require('aws-sdk'),
     mime = require('mime'),
     pascalCase = require('pascal-case'),
     File = require('vinyl'),
-    gutil = require('gulp-util');
+    gutil = require('gulp-util'),
+    _ = require('lodash');
 
 var PLUGIN_NAME = 'gulp-awspublish';
 
@@ -281,7 +282,7 @@ Publisher.prototype.cache = function(options) {
       } else if (file.s3.etag) {
         _this._cache[file.s3.path] = {
           etag: file.s3.etag,
-          headers: {}
+          headers: _.clone(file.s3.headers)
         };
       }
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "aws-sdk": "^2.1.16",
     "clone": "0.x",
     "gulp-util": "2.x",
+    "lodash": "^3.10.1",
     "mime": "1.x",
     "pad-component": "0.x",
     "pascal-case": "^1.1.0",


### PR DESCRIPTION
As per #73, the current caching implementation doesn't take header changes into account. This is still a WIP until the following is done:

- [ ] Sanity checks
- [ ] Tests
- [ ] Update docs

## Cache File Format Change

The cache file format has been updated to include the headers:

```json
{
  "<file.s3.path>": {
    "etag": "<etag>",
    "headers": {
      "header1": "header1-value",
      "header2": "header2-value"
    }
  }
}
```

When loading the cache file, it'll upgrade the old format to the new format (backwards compatibility).

## Implementation

From what I found with the current implementation, there are two states that are affected: `cache` and `skip`. The `skip` state does the same work as the `cache` comparison, except it compares with the current headers of the actual S3 object.

The `cache()` stream can now take an option to include headers as part of the cache check:

```javascript
.pipe(cache({ headers: true }))
```

For the `cache` state, the etag and all headers set on `file.s3.headers` are compared against the cached values. If a header is added, deleted or modified, the file's state is not set to `cache`.

For the `skip` state, the etag and all headers set on `file.s3.headers` are compared against the
normalized response headers.  If a header is added, deleted or modified, the file's state is not set to `skip`. However, because the `x-amz-acl` header uses a *name* of a canned ACL, it can't compared since the canned ACL is transformed into a full ACL on the object. Using `client.getObjectAcl()` could be used, to get the full ACL and then map it back to the canned name, but that seems to difficult. So, if the `x-amz-acl` changes, the user should use the `force` option on the `publish()` stream. 

Also, the cache `headers` option is ignored when doing the comparison for the `skip` state because `skip` is used *regardless* of caching being enabled/disabled.

## Questions

1. The current implementation always reads from the cache file but the `cache()` stream isn't used. Should this be changed to *not* read from the cache unless the `cache()` option is used? It could lead to confusing behavior with the current implementation.

2. In #73 @pgherveou mentioned specifying the headers to be compared. The problem I ran into with this is what about the `skip` state? If the user doesn't use cache, we still should be comparing headers so that the file isn't skipped when headers change. As it stands right now, having the `headers` option on `cache()` doesn't totally make sense (since it affects the `cache` and `skip` states). Should we remove the option all together and compare *all* headers for both the `cache` and `skip` states?

:smile: 