### PR TITLE
Update README with required permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ gulp.task('publish', function() {
 
 * Note: In order for publish to work on S3, your policiy has to allow the following S3 actions:
 - "s3:PutObject",
+- "s3:PutObjectAcl" (if setting an ACL, which is done by default),
 - "s3:GetObject",
 - "s3:DeleteObject",
 - "s3:ListMultipartUploadParts",


### PR DESCRIPTION
I ran into an issue today where `s3:PutObjectAcl` was needed with the default settings.

Fixes #71 