### PR TITLE
Bump Node engine requirement to 12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ with your **testing bucket** credentials, then run mocha.
 
 create a through stream, that gzip file and add Content-Encoding header.
 
+* Note: Node version 0.12.x or later is required in order to use `awspublish.gzip`. If you need an older node engine to work with gzipping, you can use [v2.0.2](https://github.com/pgherveou/gulp-awspublish/tree/v2.0.2).
+
 Available options:
   - ext: file extension to add to gzipped file (eg: { ext: '.gz' })
   - Any options that can be passed to [zlib.gzip](https://nodejs.org/api/zlib.html#zlib_options)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mocha-lcov-reporter": "*"
   },
   "engines": {
-    "node": ">=0.8.0",
+    "node": ">=0.12.0",
     "npm": ">=1.2.10"
   },
   "licenses": [


### PR DESCRIPTION
Require node `0.12` or later to avoid #86.

Tested successfully in node versions `0.12.0`, `0.12.7`, and `4.1.0`.