### PR TITLE
Added region to the docs as it should really always be present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ gulp.task('publish', function() {
   // create a new publisher using S3 options
   // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
   var publisher = awspublish.create({
+    region: 'your-region-id',
     params: {
       Bucket: '...'
     }


### PR DESCRIPTION
This is to help avoid an "error" when aws issues a 301 redirect when publishing to a bucket, apparently only there is a '.' in the bucket name. By including the region, and all buckets are defined with a region, the error is always avoided. The command line client puts this in it's profile file under .aws. 