### PR TITLE
Use more specific dependency versions with carets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   },
   "dependencies": {
     "aws-sdk": "^2.1.16",
-    "clone": "0.x",
-    "gulp-util": "2.x",
-    "mime": "1.x",
-    "pad-component": "0.x",
+    "clone": "^0.2.0",
+    "gulp-util": "^2.2.20",
+    "mime": "^1.3.4",
+    "pad-component": "0.0.1",
     "pascal-case": "^1.1.0",
-    "through2": "0.x",
+    "through2": "^0.6.5",
     "vinyl": "^0.4.6",
     "xml-json": "^2.0.2"
   },


### PR DESCRIPTION
Hi,

In my project which using gulp-awspublish and npm 3 (installs packages flattened by default), I found too old dependency packages are installed for gulp-awspublish and causes problems because of version specifications like `0.x`.

This pull request makes package dependency more specific by using `^` + latest package versions to avoid such problems.