### PR TITLE
Iterate all S3 objects when checking files to delete in sync

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,8 +113,8 @@ function listObjects(client, marker, maxKeys, prefix, keysStream) {
       keysStream.emit('data', item.Key.toString());
     });
 
-    if (data.IsTruncated) {
-      var nextMarker = data.Contents[data.Contents.length - 1].Key;
+    var nextMarker = data.Contents.length > 0 ? data.Contents[data.Contents.length - 1].Key : null;
+    if (data.IsTruncated && nextMarker && nextMarker !== marker) {
       listObjects(client, nextMarker, maxKeys, prefix, keysStream);
     } else {
       keysStream.emit('end');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 var AWS = require('aws-sdk'),
-    converter = require('xml-json'),
     Stream = require('stream'),
     fs = require('fs'),
     through = require('through2'),
@@ -102,6 +101,35 @@ function buildDeleteMultiple(keys) {
 }
 
 module.exports._buildDeleteMultiple = buildDeleteMultiple;
+
+function listObjects(client, marker, maxKeys, prefix, keysStream) {
+  client.listObjects({ Marker: marker, MaxKeys: maxKeys, Prefix: prefix }, function (err, data) {
+    if (err) {
+      keysStream.emit('error', err);
+      return;
+    }
+
+    data.Contents.forEach(function (item) {
+      keysStream.emit('data', item.Key.toString());
+    });
+
+    if (data.IsTruncated) {
+      var nextMarker = data.Contents[data.Contents.length - 1].Key;
+      listObjects(client, nextMarker, maxKeys, prefix, keysStream);
+    } else {
+      keysStream.emit('end');
+    }
+  });
+}
+
+function listAllKeys(client, maxKeys, prefix) {
+  var stream = new Stream;
+  stream.readable = true;
+  listObjects(client, null, maxKeys, prefix, stream);
+  return stream;
+}
+
+module.exports._listAllKeys = listAllKeys;
 
 /**
  * create a through stream that gzip files
@@ -372,9 +400,7 @@ Publisher.prototype.sync = function(prefix) {
     var toDelete = [],
         lister;
 
-    lister = client.listObjects({ Prefix: prefix })
-      .createReadStream()
-      .pipe(converter('Key'));
+    lister = listAllKeys(client, null, prefix);
 
     lister.on('data', function (key) {
       var deleteFile;

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "pad-component": "0.x",
     "pascal-case": "^1.1.0",
     "through2": "0.x",
-    "vinyl": "^0.4.6",
-    "xml-json": "^2.0.2"
+    "vinyl": "^0.4.6"
   },
   "devDependencies": {
     "chai": "*",

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ describe('gulp-awspublish', function () {
     var deleteParams = awspublish._buildDeleteMultiple([
       'test/hello.txt',
       'test/hello2.txt',
-      'test/hello.txtgz'
+      'test/hello.txt.gz'
     ]);
 
     publisher.client.deleteObjects(deleteParams, done);
@@ -290,7 +290,7 @@ describe('gulp-awspublish', function () {
       var deleteParams = awspublish._buildDeleteMultiple([
         'test/hello.txt',
         'test/hello2.txt',
-        'test/hello.txtgz'
+        'test/hello.txt.gz'
       ]);
       publisher.client.deleteObjects(deleteParams, done);
     });
@@ -310,6 +310,17 @@ describe('gulp-awspublish', function () {
         var params = awspublish._toAwsParams(file);
         publisher.client.putObject(params, done);
       });
+    });
+
+    it('should iterate all S3 objects', function(done) {
+      var stream = awspublish._listAllKeys(publisher.client, 2, '');
+
+      stream
+        .pipe(es.writeArray(function(err, keys) {
+          expect(err).not.to.exist;
+          expect(keys.join(' ')).to.eq('bar.txt foo/1.txt foo/2.txt foo/3.txt');
+          done(err);
+        }));
     });
 
     it('should sync bucket with published data', function(done) {


### PR DESCRIPTION
This should fix #93.

I'm not fluent with Node streams, so there might be a cleaner way to do this. I initially tried to make a `client.listObjects().createReadStream()` based solution like the original one, but ran into problems with XML to JSON conversion. I checked a couple libraries for it, but none of them provided stream based full XML to JSON conversion. Using the callback version of `client.listObjects()` has the convenience of providing a JavaScript object in the callback.
