### PR TITLE
Cache file options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ gulp.task('publish', function() {
     params: {
       Bucket: '...'
     }
+  }, {
+    cacheRoot: 'your-cache-location',
+    cacheHidden: Boolean
   });
 
   // define custom headers
@@ -120,10 +123,12 @@ Available options:
   - ext: file extension to add to gzipped file (eg: { ext: '.gz' })
   - Any options that can be passed to [zlib.gzip](https://nodejs.org/api/zlib.html#zlib_options)
 
-### awspublish.create(options)
+### awspublish.create(config, options)
 
 Create a Publisher.
-Options are used to create an `aws-sdk` S3 client. At a minimum you must pass a `bucket` option, to define the site bucket. You can find all available options in the [AWS SDK documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property).
+The config object is used to create an `aws-sdk` S3 client. At a minimum you must pass a `Bucket` key, to define the site bucket. You can find all available options in the [AWS SDK documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property).
+
+The options object allows you to define the location of the cached hash digests and determine if they are hidden or not. By default, they will be saved in your projects root folder in a hidden file called '.awspublish-' + 'name-of-your-bucket'.
 
 #### Credentials
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ gulp.task('publish', function() {
       Bucket: '...'
     }
   }, {
-    cacheRoot: 'your-cache-location',
-    cacheHidden: Boolean
+    cacheFile: 'your-cache-location'
   });
 
   // define custom headers
@@ -128,7 +127,7 @@ Available options:
 Create a Publisher.
 The config object is used to create an `aws-sdk` S3 client. At a minimum you must pass a `Bucket` key, to define the site bucket. You can find all available options in the [AWS SDK documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property).
 
-The options object allows you to define the location of the cached hash digests and determine if they are hidden or not. By default, they will be saved in your projects root folder in a hidden file called '.awspublish-' + 'name-of-your-bucket'.
+The options object allows you to define the location of the cached hash digests. By default, they will be saved in your projects root folder in a hidden file called '.awspublish-' + 'name-of-your-bucket'.
 
 #### Credentials
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,8 +173,15 @@ module.exports.reporter = function(param) {
  * @api private
  */
 
-function Publisher(config) {
+function Publisher(config, options) {
   this.config = config;
+
+  var defaultOptions = {
+    'cacheRoot': './',
+    'cacheHidden': true
+  }
+
+  this.options = options || defaultOptions;
   this.client = new AWS.S3(config);
 
   // load cache
@@ -198,7 +205,10 @@ Publisher.prototype.getCacheFilename = function() {
     throw new Error('Missing `params.Bucket` config value.');
   }
 
-  return (this.config.cacheRoot + '/' || '') + '.awspublish-' + bucket;
+  var folder = this.options.cacheRoot ? this.options.cacheRoot + '/' : '';
+  var cacheName = this.options.cacheHidden  ? '.awspublish-' + bucket : 'awspublish-' + bucket;
+
+  return folder + cacheName;
 };
 
 /**
@@ -411,6 +421,6 @@ Publisher.prototype.sync = function(prefix) {
  * @api public
  */
 
-exports.create = function(options){
-  return new Publisher(options);
+exports.create = function(config, options){
+  return new Publisher(config, options);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,14 +175,17 @@ module.exports.reporter = function(param) {
 
 function Publisher(config, options) {
   this.config = config;
+  this.client = new AWS.S3(config);
+  var bucket = this.config.params.Bucket;
 
-  var defaultOptions = {
-    'cacheRoot': './',
-    'cacheHidden': true
+  if (!bucket) {
+    throw new Error('Missing `params.Bucket` config value.');
   }
 
-  this.options = options || defaultOptions;
-  this.client = new AWS.S3(config);
+  // init Cache file
+  this._cacheFile = options && options.cacheFile
+    ? options.cacheFile
+    : '.awspublish-' + bucket;
 
   // load cache
   try {
@@ -199,16 +202,7 @@ function Publisher(config, options) {
  */
 
 Publisher.prototype.getCacheFilename = function() {
-  var bucket = this.config.params['Bucket'];
-
-  if (!bucket) {
-    throw new Error('Missing `params.Bucket` config value.');
-  }
-
-  var folder = this.options.cacheRoot ? this.options.cacheRoot + '/' : '';
-  var cacheName = this.options.cacheHidden  ? '.awspublish-' + bucket : 'awspublish-' + bucket;
-
-  return folder + cacheName;
+  return this._cacheFile;
 };
 
 /**


### PR DESCRIPTION
Add ability to define the location of the cache and the visibility of the hash file itself.

The background is that we use several plugins and some custom code for caching in production. Ideally we wanted them to store all the digests in one dedicated folder and not in the root. Also, the fact that the file was hidden by default made it hard to view it in the AWS-S3 console. That option was purely for more convenience.