### PR TITLE
Refactor sync method to allow exclusions in file deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,11 @@ Consecutive runs of publish will use this file to avoid reuploading identical fi
 
 Cache file is save in the current working dir and is named `.awspublish-<bucket>`. The cache file is flushed to disk every 10 files just to be safe.
 
-#### Publisher.sync([options])
+#### Publisher.sync([prefix], [whitelistedFiles])
 
 create a transform stream that delete old files from the bucket.
-Available options:
   - prefix: prefix to sync a specific directory
-  - whitelist: array that can contain regular expressions or strings that match against filenames that
+  - whitelistedFiles: array that can contain regular expressions or strings that match against filenames that
                should never be deleted from the bucket.
 
 e.g.

--- a/README.md
+++ b/README.md
@@ -197,12 +197,25 @@ Consecutive runs of publish will use this file to avoid reuploading identical fi
 
 Cache file is save in the current working dir and is named `.awspublish-<bucket>`. The cache file is flushed to disk every 10 files just to be safe.
 
-#### Publisher.sync([prefix])
+#### Publisher.sync([options])
 
 create a transform stream that delete old files from the bucket.
-You can speficy a prefix to sync a specific directory.
+Available options:
+  - prefix: prefix to sync a specific directory
+  - whitelist: array that can contain regular expressions or strings that match against filenames that
+               should never be deleted from the bucket.
 
-> **warning** `sync` will delete files in your bucket that are not in your local folder.
+e.g.
+```js
+// only directory bar will be synced
+// files in folder /foo/bar and file baz.txt will not be removed from the bucket despite not being in your local folder
+gulp.src('./public/*')
+  .pipe(publisher.publish())
+  .pipe(publisher.sync({ prefix: 'bar', whitelist: [/^foo\/bar/, 'baz.txt'] }))
+  .pipe(awspublish.reporter());
+```
+
+> **warning** `sync` will delete files in your bucket that are not in your local folder unless they're whitelisted.
 
 ```js
 // this will publish and sync bucket files with the one in your public directory

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,6 +91,33 @@ function initFile(file) {
   return file;
 }
 
+/**
+ * init file s3 hash
+ * @param  {String} key filepath
+ * @param  {Array} whitelist list of expressions that match against files that should not be deleted
+ *
+ * @return {Boolean} shouldDelete whether the file should be deleted or not
+ * @api private
+ */
+
+function fileShouldBeDeleted (key, whitelist) {
+  for (var i = 0; i < whitelist.length; i++) {
+    var expr = whitelist[i];
+    if (expr instanceof RegExp) {
+      if (expr.test(key)) {
+        return false;
+      }
+    } else if (typeof expr === 'string') {
+      if (expr === key) {
+        return false;
+      }
+    } else {
+      throw new Error('whitelist param can only contain regular expressions or strings');
+    }
+  }
+  return true;
+}
+
 function buildDeleteMultiple(keys) {
   if (!keys || !keys.length) return;
 
@@ -181,7 +208,7 @@ function Publisher(AWSConfig, cacheOptions) {
   if (!bucket) {
     throw new Error('Missing `params.Bucket` config value.');
   }
-  
+
 
   // init Cache file
   this._cacheFile = cacheOptions && cacheOptions.cacheFileName
@@ -355,18 +382,21 @@ Publisher.prototype.publish = function (headers, options) {
 
 /**
  * Sync file in stream with file in the s3 bucket
- * @param {String} prefix
+ * @param {Object} options
+ * @param {String} options.prefix prefix to sync a specific directory
+ * @param {Array} options.whitelist list of expressions that match against files that should not be deleted
  *
  * @return {Stream} a transform stream that stream both new files and delete files
  * @api public
  */
 
-Publisher.prototype.sync = function(prefix) {
+Publisher.prototype.sync = function(options) {
   var client = this.client,
       stream = new Stream.Transform({ objectMode : true }),
-      newFiles = {};
-
-  if (!prefix) prefix = '';
+      newFiles = {},
+      options = options || {},
+      prefix = options.prefix || '',
+      whitelist = options.whitelist || [];
 
   // push file to stream and add files to s3 path to list of new files
   stream._transform = function(file, encoding, cb) {
@@ -386,6 +416,7 @@ Publisher.prototype.sync = function(prefix) {
     lister.on('data', function (key) {
       var deleteFile;
       if (newFiles[key]) return;
+      if (!fileShouldBeDeleted(key, whitelist)) return;
 
       deleteFile = new File({});
       deleteFile.s3 = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -383,7 +383,7 @@ Publisher.prototype.publish = function (headers, options) {
 /**
  * Sync file in stream with file in the s3 bucket
  * @param {String} prefix prefix to sync a specific directory
- * @param {Array} whitelist list of expressions that match against files that should not be deleted
+ * @param {Array} whitelistedFiles list of expressions that match against files that should not be deleted
  *
  * @return {Stream} a transform stream that stream both new files and delete files
  * @api public

--- a/lib/index.js
+++ b/lib/index.js
@@ -382,21 +382,19 @@ Publisher.prototype.publish = function (headers, options) {
 
 /**
  * Sync file in stream with file in the s3 bucket
- * @param {Object} options
- * @param {String} options.prefix prefix to sync a specific directory
- * @param {Array} options.whitelist list of expressions that match against files that should not be deleted
+ * @param {String} prefix prefix to sync a specific directory
+ * @param {Array} whitelist list of expressions that match against files that should not be deleted
  *
  * @return {Stream} a transform stream that stream both new files and delete files
  * @api public
  */
 
-Publisher.prototype.sync = function(options) {
+Publisher.prototype.sync = function(prefix, whitelistedFiles) {
   var client = this.client,
       stream = new Stream.Transform({ objectMode : true }),
       newFiles = {},
-      options = options || {},
-      prefix = options.prefix || '',
-      whitelist = options.whitelist || [];
+      prefix = prefix || '',
+      whitelistedFiles = whitelistedFiles || [];
 
   // push file to stream and add files to s3 path to list of new files
   stream._transform = function(file, encoding, cb) {
@@ -416,7 +414,7 @@ Publisher.prototype.sync = function(options) {
     lister.on('data', function (key) {
       var deleteFile;
       if (newFiles[key]) return;
-      if (!fileShouldBeDeleted(key, whitelist)) return;
+      if (!fileShouldBeDeleted(key, whitelistedFiles)) return;
 
       deleteFile = new File({});
       deleteFile.s3 = {

--- a/test/index.js
+++ b/test/index.js
@@ -32,7 +32,7 @@ describe('gulp-awspublish', function () {
 
     publisher.client.deleteObjects(deleteParams, done);
   });
-  
+
   after(function(){
     try { fs.unlinkSync(path.join(__dirname, publisher.getCacheFilename())); } catch (err) {}
     try { fs.unlinkSync(path.join(__dirname, '../testCacheFile')); } catch (err) { }
@@ -312,7 +312,6 @@ describe('gulp-awspublish', function () {
         .pipe(es.writeArray(function (err, files) {
           expect(err).not.to.exist;
           expect(files).to.have.length(1);
-          console.log(files);
           expect(files[0].s3.path).to.eq('test/simulate.txt');
           publisher.client.headObject({ Key: '/test/simulate.txt' }, function (err) {
             expect(err.statusCode).to.eq(404);

--- a/test/index.js
+++ b/test/index.js
@@ -357,7 +357,7 @@ describe('gulp-awspublish', function () {
       var stream = gutil.noop();
 
       stream
-        .pipe(publisher.sync({ prefix: 'foo'}))
+        .pipe(publisher.sync('foo'))
         .pipe(es.writeArray(function (err, arr) {
           expect(err).to.not.exist;
           var deleted = arr.filter(function (file) {
@@ -378,7 +378,7 @@ describe('gulp-awspublish', function () {
       var stream = gutil.noop();
 
       stream
-        .pipe(publisher.sync({ whitelist: [/foo/]}))
+        .pipe(publisher.sync('', [/foo/]))
         .pipe(es.writeArray(function (err, arr) {
           expect(err).to.not.exist;
 
@@ -401,7 +401,7 @@ describe('gulp-awspublish', function () {
       var stream = gutil.noop();
 
       stream
-        .pipe(publisher.sync({ whitelist: ['foo/2.txt', 'fooo/3.txt']}))
+        .pipe(publisher.sync('', ['foo/2.txt', 'fooo/3.txt']))
         .pipe(es.writeArray(function (err, arr) {
           expect(err).to.not.exist;
 


### PR DESCRIPTION
This pull request is an attempt to resolve #107

Sync method now receives an options object as only param.
The options are:
- prefix: prefix to sync a specific directory
- whitelist: array of strings or regular expressions to match against filenames that should not be deleted from the bucket

