### PR TITLE
Add `publish(.., {noAcl: true})` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Create a through stream, that push files to s3.
 - header: hash of headers to add or override to existing s3 headers.
 - options: optional additional publishing options
   - force: bypass cache / skip
+  - noAcl: do not set x-amz-acl by default
   - simulate: debugging option to simulate s3 upload
   - createOnly: skip file updates
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -283,6 +283,9 @@ Publisher.prototype.cache = function() {
  *
  * available options are:
  * - force {Boolean} force upload
+ * - noAcl: do not set x-amz-acl by default
+ * - simulate: debugging option to simulate s3 upload
+ * - createOnly: skip file updates
  *
  * @return {Stream}
  * @api public
@@ -299,7 +302,7 @@ Publisher.prototype.publish = function (headers, options) {
   if (!headers) headers = {};
 
   // add public-read header by default
-  if(!headers['x-amz-acl']) headers['x-amz-acl'] = 'public-read';
+  if(!headers['x-amz-acl'] && !options.noAcl) headers['x-amz-acl'] = 'public-read';
 
   return through.obj(function (file, enc, cb) {
     var header, etag;


### PR DESCRIPTION
In cases where bucket access is controlled by bucket policy, and where
the credentials used for upload do not allow PutObjectAcl (which is
actually a very powerful call!), it's best not to specify x-amz-acl at
all.  This provides an option to `publisher.publish` to skip adding
this default header.