### PR TITLE
Drop unmaintained xml-json for lib/converter.js

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,0 +1,9 @@
+var xmlNodes = require('xml-nodes');
+var xmlObjects = require('xml-objects');
+var pumpify = require('pumpify');
+
+module.exports = function(nodeFilter) {
+  var nodes = xmlNodes(nodeFilter);
+  var objects = xmlObjects({ explicitRoot: false, explicitArray: false, mergeAttrs: true });
+  return pumpify.obj(nodes, objects)
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var AWS = require('aws-sdk'),
-    converter = require('xml-json'),
+    converter = require('./converter'),
     Stream = require('stream'),
     fs = require('fs'),
     through = require('through2'),

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "mime": "^1.3.4",
     "pad-component": "^0.0.1",
     "pascal-case": "^1.1.0",
+    "pumpify": "^1.3.5",
     "through2": "^2.0.1",
     "vinyl": "^0.4.6",
-    "xml-json": "^2.0.2"
+    "xml-nodes": "^0.1.5",
+    "xml-objects": "^1.0.1"
   },
   "devDependencies": {
     "chai": "*",


### PR DESCRIPTION
This PR removes the `xml-json` dependency and replaces it with `lib/converter.js`.  This is identical to [xml-json/index.js](https://github.com/maxogden/xml-json/blob/master/index.js) without the `extend` dep for passing extra options.

Why?

`xml-json` is tiny, untested, 2yrs unmaintained, and its outdated dependency `xml-objects` is failing on CircleCI (see https://github.com/maxogden/xml-json/pull/2).  The updated `xml-objects` [uses `through2` streams](https://github.com/timhudson/xml-objects/commit/e75e39723fffa3cd3f0c54f82549427f44e9f14f) and has no issues.  I figure it is best to just add to the lib here instead of trying to update the abandoned `xml-json` dep.

I've confirmed `publisher.sync()` is working on this fork, both locally and on CI.