### PR TITLE
added possibility to set different headers for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ gulp.task('publish', function() {
 }
 ```
 
+## Custom headers
+
+You can add different headers to different files using glob filter syntax:
+
+```
+	var headers = {
+		"Cache-Control": 'max-age=86400, no-transform, public',
+		"fileFilters": [
+			{
+				"filter": '**/*.txt',
+				"Cache-Control": 'max-age=604800, no-transform, public'
+			},
+			{
+				"filter": ['**/*.jpg', '**/*.png'],
+				"Cache-Control": 'max-age=315360000, no-transform, public'
+			},
+		]
+	};
+
+```
+
 ## Testing
 
 1. Create an S3 bucket which will be used for the tests. Optionally create an IAM user for running the tests.

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ var AWS = require('aws-sdk'),
     mime = require('mime'),
     pascalCase = require('pascal-case'),
     File = require('vinyl'),
-    gutil = require('gulp-util');
+    gutil = require('gulp-util'),
+		minimatch = require('minimatch');
 
 var PLUGIN_NAME = 'gulp-awspublish';
 
@@ -54,6 +55,10 @@ function toAwsParams(file) {
   var headers = file.s3.headers || {};
 
   for (var header in headers) {
+		if (header === 'Cache-Control') {
+			//console.log(file.s3.path, headers[header]);
+		}
+
     if (header === 'x-amz-acl') {
 
       params.ACL = headers[header];
@@ -340,8 +345,40 @@ Publisher.prototype.publish = function (headers, options) {
       // add content-length header
       if (!file.s3.headers['Content-Length']) file.s3.headers['Content-Length'] = file.contents.length;
 
+			function test(filter, fileName) {
+				if (!filter) { return false; }
+
+				if (Array.isArray(filter)) {
+					return filter.some(pattern => minimatch(file.relative, pattern));
+				}
+
+				if (typeof filter === 'string') {
+					return minimatch(file.relative, filter);
+				}
+				
+				return false;
+			}
+
       // add extra headers
-      for (header in headers) file.s3.headers[header] = headers[header];
+      for (header in headers){
+				if (header === 'fileFilters') {
+					headers[header].forEach(el => {
+						if (test(el.filter, file.relative)) {
+							for (var fileHeader in el) {
+								if (fileHeader === 'filter') { continue; }
+
+								file.s3.headers[fileHeader] = el[fileHeader];
+							}
+						}
+					});
+
+					continue;
+				}
+
+				file.s3.headers[header] = headers[header];
+			}
+
+			//console.log(file.s3.path, file.s3.headers);
 
       if (options.simulate) return cb(null, file);
 


### PR DESCRIPTION
Following up to this issue: https://github.com/pgherveou/gulp-awspublish/issues/136, I wrote some code (+ tests) to support the possibility to set different headers for some file patterns, using glob syntax (with minimatch).

I had to slightly change the structure of headers configuration object to support this feature, if anyone has better suggestions about the naming or syntax is welcome :)