### PR TITLE
Use mime-types to solve insecure dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ var AWS = require('aws-sdk'),
     through = require('through2'),
     zlib = require('zlib'),
     crypto = require('crypto'),
-    mime = require('mime'),
+    mime = require('mime-types'),
     pascalCase = require('pascal-case'),
     Vinyl = require('vinyl'),
     PluginError = require('plugin-error');
@@ -37,7 +37,7 @@ function md5Hash(buf) {
 
 function getContentType(file) {
   var mimeType = mime.lookup(file.unzipPath || file.path);
-  var charset = mime.charsets.lookup(mimeType);
+  var charset = mime.charset(mimeType);
 
   return charset
     ? mimeType + '; charset=' + charset.toLowerCase()

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "aws-sdk": "^2.1.16",
     "clone": "^1.0.2",
     "fancy-log": "^1.3.2",
-    "mime": "^1.3.4",
+    "mime-types": "^2.1.18",
     "pad-component": "^0.0.1",
     "pascal-case": "^2.0.0",
     "plugin-error": "^0.1.2",


### PR DESCRIPTION
The current `mime` dependency has this vulnerability https://nodesecurity.io/advisories/535. 
I thinking about replacing it with https://www.npmjs.com/package/mime-types which is almost a drop-in replacement.

Thought about updating to `mime@2` but seems like it won't support charsets anymore 🤔 