### PR TITLE
Fix JSON example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ and the credentials of the user who will run the tests.
   "params": {
     "Bucket": "<test-bucket-name>"
   },
-  "accessKeyId": "<your-access-key-id>",
-  "secretAccessKey": "<your-secret-access-key>",
-  "signatureVersion": "v3"
+  "credentials": {
+    "accessKeyId": "<your-access-key-id>",
+    "secretAccessKey": "<your-secret-access-key>",
+    "signatureVersion": "v3"
+  }
 }
 ```
 


### PR DESCRIPTION
Resolving https://github.com/pgherveou/gulp-awspublish/issues/144

I saw the PR https://github.com/pgherveou/gulp-awspublish/pull/135 but few minor things keep me from merging it right directly (ping @gfrivolt 🙏):
  - The bracket style is different 😅 
  - The JS example (without the `credentials` property) is actually valid based on AWS.S3 documentation https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property. I didn't go deep in the code/doc but seems like setting `signatureVersion` requires `credentials` property.
