### PR TITLE
Add option to gzip to skip larger gzip files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -139,6 +139,7 @@ module.exports._buildDeleteMultiple = buildDeleteMultiple;
  *
  * options keys are:
  *   ext: extension to add to gzipped files
+ *   smaller: whether to only gzip files if the result is smaller
  *
  * @return {Stream}
  * @api public
@@ -165,12 +166,13 @@ module.exports.gzip = function(options) {
     if (file.isBuffer()) {
       initFile(file);
 
-      // add content-encoding header
-      file.s3.headers['Content-Encoding'] = 'gzip';
-
       // zip file
       zlib.gzip(file.contents, options, function(err, buf) {
         if (err) return cb(err);
+        if (options.smaller && buf.length >= file.contents.length)
+          return cb(err, file);
+        // add content-encoding header
+        file.s3.headers['Content-Encoding'] = 'gzip';
         file.unzipPath = file.path;
         file.path += options.ext;
         file.s3.path += options.ext;


### PR DESCRIPTION
This pull request adds an option to `gzip` to only produce gzipped files when the resulting size is smaller than the original file. Some files don't benefit from gzipping and see an increase in size, this option is allows the file to be left alone in this case and uploaded without gzip.

(*Sorry if this pull request is a little unclear, it's late here*).