### PR TITLE
Run automated tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '0.8'
-  - '0.10'
-after_script:
-  - npm run coveralls
+  - 6
+  - 8
+  - 10

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gulp-awspublish
 
-[![NPM version][npm-image]][npm-url] [![Dependency Status][depstat-image]][depstat-url]
+[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][depstat-image]][depstat-url]
 
 > awspublish plugin for [gulp](https://github.com/wearefractal/gulp)
 
@@ -351,3 +351,5 @@ https://www.npmjs.com/package/gulp-cloudfront-invalidate-aws-publish
 [npm-image]: https://badge.fury.io/js/gulp-awspublish.svg
 [depstat-url]: https://david-dm.org/pgherveou/gulp-awspublish
 [depstat-image]: https://david-dm.org/pgherveou/gulp-awspublish.svg
+[travis-url]: https://www.travis-ci.org/pgherveou/gulp-awspublish
+[travis-image]: https://www.travis-ci.org/pgherveou/gulp-awspublish.svg?branch=master

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,16 @@ var fs = require('fs'),
 describe('gulp-awspublish', function() {
   this.timeout(10000);
 
-  var credentials = JSON.parse(fs.readFileSync('aws-credentials.json', 'utf8')),
+  var credentials = process.env.TRAVIS ? {
+      params: {
+        Bucket: process.env.bucket + '-' + process.env.TRAVIS_NODE_VERSION
+      },
+      credentials: {
+        accessKeyId: process.env.accessKeyId,
+        secretAccessKey: process.env.secretAccessKey,
+        signatureVersion: 'v3'
+      }
+    } : JSON.parse(fs.readFileSync('aws-credentials.json', 'utf8')),
     publisher = awspublish.create(credentials);
 
   // remove files

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
---growl
 --check-leaks
 --reporter spec
 --colors


### PR DESCRIPTION
Updating the tests to run them on Travis, according to https://github.com/pgherveou/gulp-awspublish/issues/163.

- Remove Node 0.8 and 0.10 (not compatible with Prettier, Mocha 🙈)
- Add Node 6, 8 and 10 (the current active versions https://github.com/nodejs/Release#release-schedule)
- Pass my AWS credentials as environment variables on Travis 🤔 
- Run tests in different S3 buckets to avoid concurrency when running parallels jobs on Travis