### PR TITLE
[FIX] Stream completion in sync

### DIFF
--- a/lib/s3-paging-stream.js
+++ b/lib/s3-paging-stream.js
@@ -35,7 +35,8 @@ module.exports = function(req, fn, opts) {
       stream.push(fn(obj));
     });
 
-    req = this.hasNextPage() ? this.nextPage() : null;
-    if (!req) stream.push(null);
+    var nextPage = this.hasNextPage() ? this.nextPage() : null;
+    if (nextPage) nextPage.send(page_handler);
+    else stream.push(null);
   }
 };


### PR DESCRIPTION
A couple of days ago I updated all of my dev dependencies for a project that uses library. At that time, my sync stopped working and I've been banging my head against the why of it. It turns out, that likely either: 
1) Due to some combination of update of dependencies, an assumption in the s3pagingStream is no longer true: that the stream will receive another call to `read` after the `page_handler` has completed, or
2) Some other change in my environment caused multiple pages to run in `sync` and it never had before. That's possible because a change in filename hash as part of my dependencies bump means that when I run this today a whole bunch of static assets are getting a new filename, meaning that the bucket is much more full than usual and therefore to finish the sync, multiple pages are needed to get the list of files.

As such, we can't rely on writing to `req` and then a call to `read` causing additional pages to work. Instead, I'm handling the next page directly in the page handler, which fixes the ability to read multiple pages.