### PR TITLE
Return empty array if nothing to delete when sync'ing.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,7 @@ function fileShouldBeDeleted(key, whitelist) {
 }
 
 function buildDeleteMultiple(Bucket, keys) {
-  if (!keys || !keys.length) return;
+  if (!keys || !keys.length) return [];
 
   var deleteObjects = keys.map(function (k) {
     return { Key: k };


### PR DESCRIPTION
When using .sync(), if there's nothing to delete, it throws the error:

> UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'map' of undefined
    at Transform.stream._flush (.../node_modules/gulp-awspublish/lib/index.js:449:65)

Returning an empty array resolves the issue.