### PR TITLE
Add option 'putOnly' to skip HEAD request

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Create a through stream, that push files to s3.
 - header: hash of headers to add or override to existing s3 headers.
 - options: optional additional publishing options
   - force: bypass cache / skip
+  - putOnly: bypass cache and head request (overrides `force`)
   - noAcl: do not set x-amz-acl by default
   - simulate: debugging option to simulate s3 upload
   - createOnly: skip file updates
@@ -212,7 +213,7 @@ Files that go through the stream receive extra properties:
 - s3.path: s3 path
 - s3.etag: file etag
 - s3.date: file last modified date
-- s3.state: publication state (create, update, delete, cache or skip)
+- s3.state: publication state (create, update, put, delete, cache or skip)
 - s3.headers: s3 headers for this file. Defaults headers are:
   - x-amz-acl: public-read
   - Content-Type
@@ -270,7 +271,7 @@ The `aws-sdk` S3 client is exposed to let you do other s3 operations.
 
 ### awspublish.reporter([options])
 
-Create a reporter that logs s3.path and s3.state (delete, create, update, cache, skip).
+Create a reporter that logs s3.path and s3.state (delete, create, update, put, cache, skip).
 
 Available options:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -353,6 +353,22 @@ Publisher.prototype.publish = function (headers, options) {
 
       if (options.simulate) return cb(null, file);
 
+      const putObject = function () {
+        const params = toAwsParams(_this.client.config.params.Bucket, file);
+        _this.client.putObject(params, function (err) {
+          if (err) return cb(err);
+
+          file.s3.date = new Date();
+          file.s3.etag = etag;
+          cb(err, file);
+        });
+      };
+
+      if (options.putOnly) {
+        file.s3.state = 'put';
+        return putObject();
+      }
+
       // get s3 headers
       const params = {
         Bucket: _this.client.config.params.Bucket,
@@ -381,15 +397,7 @@ Publisher.prototype.publish = function (headers, options) {
           // update: file are different
         } else {
           file.s3.state = res.ETag ? 'update' : 'create';
-
-          const params = toAwsParams(_this.client.config.params.Bucket, file);
-          _this.client.putObject(params, function (err) {
-            if (err) return cb(err);
-
-            file.s3.date = new Date();
-            file.s3.etag = etag;
-            cb(err, file);
-          });
+          putObject();
         }
       });
     }

--- a/test/index.js
+++ b/test/index.js
@@ -391,6 +391,28 @@ describe('gulp-awspublish', function () {
       stream.end();
     });
 
+    it('should put object without head object', function (done) {
+      var stream = publisher.publish({}, { putOnly: true });
+      stream.pipe(
+        collectFiles(function (err, files) {
+          expect(err).not.to.exist;
+          expect(files).to.have.length(1);
+          expect(files[0].s3.state).to.eq('put');
+          done(err);
+        })
+      );
+
+      stream.write(
+        new Vinyl({
+          path: '/test/hello.txt',
+          base: '/',
+          contents: Buffer.from('hello world'),
+        })
+      );
+
+      stream.end();
+    });
+
     it('should have a the correct default cachefile name', function (done) {
       var publisherWithDefaultCache = awspublish.create(credentials),
         stream = publisherWithDefaultCache.publish(),


### PR DESCRIPTION
I am introducing the `putOnly` option to bypass the HEAD request and any local cache. This will be particularly useful when a CI server is deploying a static web app, as it often involves uploading many small files with unique filenames containing hash values. 

By using the `putOnly` option, we can significantly speed up this type of deployment.