### PR TITLE
Do not pass any ACL header by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ gulp.task('publish', function () {
       .pipe(awspublish.gzip({ ext: '.gz' }))
 
       // publisher will add Content-Length, Content-Type and headers specified above
-      // If not specified it will set x-amz-acl to public-read by default
       .pipe(publisher.publish(headers))
 
       // create a cache file to speed up consecutive uploads
@@ -97,20 +96,13 @@ gulp.task('publish', function () {
 
 ### Bucket permissions
 
-By default, the plugin works only when public access to the bucket is **not blocked**:
-
-- Block all public access: **Off**
-  - Block public access to buckets and objects granted through new access control lists (ACLs): Off
-  - Block public access to buckets and objects granted through any access control lists (ACLs): Off
-  - Block public access to buckets and objects granted through new public bucket policies: Off
-  - Block public and cross-account access to buckets and objects through any public bucket policies: Off
-
-When dealing with a private bucket, make sure to pass the option `{ noAcl: true }` or a value for the `x-amz-acl` header:
+By default, if no `x-amz-acl` header is passed, the uploaded object will inherit from the bucket setting. If you have specific requirements for the uploaded object, make sure to pass a value for the `x-amz-acl` header:
 
 ```js
-publisher.publish({}, { noAcl: true });
 publisher.publish({ 'x-amz-acl': 'something' });
 ```
+
+See [canned ACL on AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#CannedACL).
 
 ## Testing
 
@@ -204,7 +196,6 @@ Create a through stream, that push files to s3.
 - options: optional additional publishing options
   - force: bypass cache / skip
   - putOnly: bypass cache and head request (overrides `force`)
-  - noAcl: do not set x-amz-acl by default
   - simulate: debugging option to simulate s3 upload
   - createOnly: skip file updates
 
@@ -215,7 +206,6 @@ Files that go through the stream receive extra properties:
 - s3.date: file last modified date
 - s3.state: publication state (create, update, put, delete, cache or skip)
 - s3.headers: s3 headers for this file. Defaults headers are:
-  - x-amz-acl: public-read
   - Content-Type
   - Content-Length
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -287,7 +287,6 @@ Publisher.prototype.cache = function () {
  *
  * available options are:
  * - force {Boolean} force upload
- * - noAcl: do not set x-amz-acl by default
  * - simulate: debugging option to simulate s3 upload
  * - createOnly: skip file updates
  *
@@ -303,10 +302,6 @@ Publisher.prototype.publish = function (headers, options) {
 
   // init param object
   if (!headers) headers = {};
-
-  // add public-read header by default
-  if (!headers['x-amz-acl'] && !options.noAcl)
-    headers['x-amz-acl'] = 'public-read';
 
   const stream = new Transform({ objectMode: true });
   stream._transform = function (file, enc, cb) {

--- a/test/index.js
+++ b/test/index.js
@@ -258,7 +258,7 @@ describe('gulp-awspublish', function () {
           expect(files[0].s3.headers['Cache-Control']).to.eq(
             headers['Cache-Control']
           );
-          expect(files[0].s3.headers['x-amz-acl']).to.eq('public-read');
+          expect(files[0].s3.headers).not.contain.keys('x-amz-acl');
           expect(files[0].s3.headers['Content-Type']).to.eq(
             'text/plain; charset=utf-8'
           );
@@ -281,8 +281,8 @@ describe('gulp-awspublish', function () {
       stream.end();
     });
 
-    it('should not send s3 header x-amz-acl if option {noAcl: true}', function (done) {
-      var stream = publisher.publish({}, { noAcl: true });
+    it('should not send s3 header x-amz-acl by default', function (done) {
+      var stream = publisher.publish({});
       stream.write(
         new Vinyl({
           path: '/test/hello3.txt',


### PR DESCRIPTION
I've encountered this issue recently while working with a private bucket. I'd like to improve the "default" behavior

1. We can reduce the API surface by removing the `noAcl` option because it's already possible to set headers via the first argument.   
2. From what I understand, when not explicitly specified, objects inherit the settings from the bucket, which seems more suitable for common cases than letting the plugin set them to 'public' by default.

I will release a major version since it's a breaking change.